### PR TITLE
release candidate schema changes for 2.0

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 20,
+  "tabWidth": 2
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-  "printWidth": 20,
+  "printWidth": 80,
   "tabWidth": 2
 }

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -5,12 +5,7 @@
   "description": "A Versa itinerary",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "schema_version",
-    "header",
-    "itemization",
-    "footer"
-  ],
+  "required": ["schema_version", "header", "itemization", "footer"],
   "properties": {
     "schema_version": {
       "title": "SchemaVersion",
@@ -59,35 +54,20 @@
           "$ref": "#/$defs/place"
         },
         "vehicle": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "description",
-            "image"
-          ],
+          "type": ["object", "null"],
+          "required": ["description", "image"],
           "properties": {
             "description": {
               "type": "string"
             },
             "license_plate_number": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vehicle_class": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "image": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "format": "uri"
             }
           }
@@ -120,19 +100,13 @@
       "title": "Customer",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "metadata"
-      ],
+      "required": ["name", "metadata"],
       "properties": {
         "name": {
           "type": "string"
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
           "maxLength": 127
@@ -148,10 +122,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "metadata": {
           "type": "array",
@@ -165,9 +136,7 @@
       "title": "Flight",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "tickets"
-      ],
+      "required": ["tickets"],
       "properties": {
         "tickets": {
           "type": "array",
@@ -177,10 +146,7 @@
           }
         },
         "itinerary_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
@@ -201,52 +167,28 @@
           "type": "string"
         },
         "aircraft_type": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "departure_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "arrival_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "departure_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "arrival_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "flight_number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "seat": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "class_of_service": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -256,14 +198,11 @@
         }
       }
     },
-
     "flight_ticket": {
       "title": "FlightTicket",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "segments"
-      ],
+      "required": ["segments"],
       "properties": {
         "segments": {
           "type": "array",
@@ -273,16 +212,10 @@
           }
         },
         "number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "record_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "passenger": {
           "oneOf": [
@@ -303,15 +236,9 @@
       "required": [],
       "properties": {
         "third_party": {
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "additionalProperties": false,
-          "required": [
-            "relation",
-            "make_primary"
-          ],
+          "required": ["relation", "make_primary"],
           "properties": {
             "relation": {
               "type": "string",
@@ -404,12 +331,7 @@
       "title": "Lodging",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "check_in",
-        "check_out",
-        "items",
-        "location"
-      ],
+      "required": ["check_in", "check_out", "items", "location"],
       "properties": {
         "check_in": {
           "type": "integer"
@@ -428,16 +350,10 @@
           }
         },
         "room": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "guests": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -451,9 +367,7 @@
       "title": "Org",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"
@@ -471,30 +385,18 @@
           ]
         },
         "legal_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "logo": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "uri"
         },
         "website": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "hostname"
         },
         "vat_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -515,16 +417,10 @@
       "required": [],
       "properties": {
         "street_address": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "city": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "region": {
           "oneOf": [
@@ -551,10 +447,7 @@
           ]
         },
         "postal_code": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "lat": {
           "oneOf": [
@@ -581,49 +474,29 @@
           ]
         },
         "tz": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     },
     "person": {
       "title": "Person",
       "type": "object",
-      "required": [
-        "metadata"
-      ],
+      "required": ["metadata"],
       "properties": {
         "first_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "last_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "preferred_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "metadata": {
           "type": "array",
@@ -640,10 +513,7 @@
       "required": [],
       "properties": {
         "name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -656,10 +526,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "url": {
           "oneOf": [
@@ -673,10 +540,7 @@
           ]
         },
         "google_place_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "image": {
           "oneOf": [
@@ -695,10 +559,7 @@
       "title": "Metadatum",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "properties": {
         "key": {
           "type": "string"
@@ -712,9 +573,7 @@
       "title": "TransitRoute",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "transit_route_items"
-      ],
+      "required": ["transit_route_items"],
       "properties": {
         "transit_route_items": {
           "type": "array",
@@ -729,9 +588,7 @@
       "title": "TransitRouteItem",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "metadata"
-      ],
+      "required": ["metadata"],
       "properties": {
         "departure_location": {
           "oneOf": [
@@ -754,16 +611,10 @@
           ]
         },
         "departure_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "arrival_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "polyline": {
           "oneOf": [
@@ -798,14 +649,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "car",
-                "taxi",
-                "rail",
-                "bus",
-                "ferry",
-                "other"
-              ]
+              "enum": ["car", "taxi", "rail", "bus", "ferry", "other"]
             }
           ]
         }
@@ -815,9 +659,7 @@
       "title": "Item",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "description"
-      ],
+      "required": ["description"],
       "properties": {
         "date": {
           "oneOf": [
@@ -834,16 +676,10 @@
           "type": "string"
         },
         "quantity": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "unit": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "unspsc": {
           "oneOf": [
@@ -873,10 +709,7 @@
           ]
         },
         "group": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "url": {
           "oneOf": [
@@ -895,10 +728,7 @@
       "title": "Doc",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "title",
-        "body"
-      ],
+      "required": ["title", "body"],
       "properties": {
         "title": {
           "type": "string"
@@ -915,10 +745,7 @@
       "required": [],
       "properties": {
         "supplemental_text": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     }

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -202,7 +202,7 @@
       "title": "FlightTicket",
       "type": "object",
       "additionalProperties": false,
-      "required": ["segments", "metadata"],
+      "required": ["segments"],
       "properties": {
         "segments": {
           "type": "array",

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -5,12 +5,7 @@
   "description": "A Versa itinerary",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "schema_version",
-    "header",
-    "itemization",
-    "footer"
-  ],
+  "required": ["schema_version", "header", "itemization", "footer"],
   "properties": {
     "schema_version": {
       "title": "SchemaVersion",
@@ -59,23 +54,14 @@
           "$ref": "#/$defs/place"
         },
         "vehicle": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "description",
-            "image"
-          ],
+          "type": ["object", "null"],
+          "required": ["description", "image"],
           "properties": {
             "description": {
               "type": "string"
             },
             "image": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "format": "uri"
             }
           }
@@ -108,19 +94,13 @@
       "title": "Customer",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name",
-        "metadata"
-      ],
+      "required": ["name", "metadata"],
       "properties": {
         "name": {
           "type": "string"
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
           "maxLength": 127
@@ -136,10 +116,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "metadata": {
           "type": "array",
@@ -153,9 +130,7 @@
       "title": "Flight",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "tickets"
-      ],
+      "required": ["tickets"],
       "properties": {
         "tickets": {
           "type": "array",
@@ -165,10 +140,7 @@
           }
         },
         "itinerary_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
@@ -189,52 +161,28 @@
           "type": "string"
         },
         "aircraft_type": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "departure_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "arrival_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "departure_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "arrival_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "flight_number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "seat": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "class_of_service": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -248,10 +196,7 @@
       "title": "FlightTicket",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "segments",
-        "metadata"
-      ],
+      "required": ["segments", "metadata"],
       "properties": {
         "segments": {
           "type": "array",
@@ -261,22 +206,13 @@
           }
         },
         "number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "record_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "passenger": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -388,12 +324,7 @@
       "title": "Lodging",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "check_in",
-        "check_out",
-        "items",
-        "location"
-      ],
+      "required": ["check_in", "check_out", "items", "location"],
       "properties": {
         "check_in": {
           "type": "integer"
@@ -412,16 +343,10 @@
           }
         },
         "room": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "guests": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -435,9 +360,7 @@
       "title": "Org",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"
@@ -455,30 +378,18 @@
           ]
         },
         "legal_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "logo": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "uri"
         },
         "website": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "hostname"
         },
         "vat_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -499,16 +410,10 @@
       "required": [],
       "properties": {
         "street_address": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "city": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "region": {
           "oneOf": [
@@ -535,10 +440,7 @@
           ]
         },
         "postal_code": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "lat": {
           "oneOf": [
@@ -565,10 +467,7 @@
           ]
         },
         "tz": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     },
@@ -576,20 +475,10 @@
       "title": "Place",
       "description": "The physical or online location where a transaction occurred",
       "type": "object",
-      "required": [
-        "name",
-        "address",
-        "phone",
-        "url",
-        "google_place_id",
-        "image"
-      ],
+      "required": [],
       "properties": {
         "name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -602,10 +491,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "url": {
           "oneOf": [
@@ -619,10 +505,7 @@
           ]
         },
         "google_place_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "image": {
           "oneOf": [
@@ -641,10 +524,7 @@
       "title": "Metadatum",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "properties": {
         "key": {
           "type": "string"
@@ -658,9 +538,7 @@
       "title": "TransitRoute",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "transit_route_items"
-      ],
+      "required": ["transit_route_items"],
       "properties": {
         "transit_route_items": {
           "type": "array",
@@ -675,9 +553,7 @@
       "title": "TransitRouteItem",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "metadata"
-      ],
+      "required": ["metadata"],
       "properties": {
         "departure_location": {
           "oneOf": [
@@ -700,16 +576,10 @@
           ]
         },
         "departure_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "arrival_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "polyline": {
           "oneOf": [
@@ -728,10 +598,7 @@
           }
         },
         "passenger": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "mode": {
           "oneOf": [
@@ -750,9 +617,7 @@
       "title": "Item",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "description"
-      ],
+      "required": ["description"],
       "properties": {
         "date": {
           "oneOf": [
@@ -769,16 +634,10 @@
           "type": "string"
         },
         "quantity": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "unit": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "unspsc": {
           "oneOf": [
@@ -808,10 +667,7 @@
           ]
         },
         "group": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "url": {
           "oneOf": [
@@ -830,10 +686,7 @@
       "title": "Doc",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "title",
-        "body"
-      ],
+      "required": ["title", "body"],
       "properties": {
         "title": {
           "type": "string"
@@ -850,10 +703,7 @@
       "required": [],
       "properties": {
         "supplemental_text": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     }

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -5,7 +5,12 @@
   "description": "A Versa itinerary",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "header", "itemization", "footer"],
+  "required": [
+    "schema_version",
+    "header",
+    "itemization",
+    "footer"
+  ],
   "properties": {
     "schema_version": {
       "title": "SchemaVersion",
@@ -54,20 +59,35 @@
           "$ref": "#/$defs/place"
         },
         "vehicle": {
-          "type": ["object", "null"],
-          "required": ["description", "image"],
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "description",
+            "image"
+          ],
           "properties": {
             "description": {
               "type": "string"
             },
             "license_plate_number": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vehicle_class": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "image": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "format": "uri"
             }
           }
@@ -100,13 +120,19 @@
       "title": "Customer",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "metadata"],
+      "required": [
+        "name",
+        "metadata"
+      ],
       "properties": {
         "name": {
           "type": "string"
         },
         "email": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "email",
           "minLength": 6,
           "maxLength": 127
@@ -122,7 +148,10 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -136,7 +165,9 @@
       "title": "Flight",
       "type": "object",
       "additionalProperties": false,
-      "required": ["tickets"],
+      "required": [
+        "tickets"
+      ],
       "properties": {
         "tickets": {
           "type": "array",
@@ -146,7 +177,10 @@
           }
         },
         "itinerary_locator": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },
@@ -167,28 +201,52 @@
           "type": "string"
         },
         "aircraft_type": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "departure_at": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "arrival_at": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "departure_tz": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "arrival_tz": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "flight_number": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "seat": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "class_of_service": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -198,11 +256,14 @@
         }
       }
     },
+
     "flight_ticket": {
       "title": "FlightTicket",
       "type": "object",
       "additionalProperties": false,
-      "required": ["segments"],
+      "required": [
+        "segments"
+      ],
       "properties": {
         "segments": {
           "type": "array",
@@ -212,10 +273,16 @@
           }
         },
         "number": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "record_locator": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "passenger": {
           "oneOf": [
@@ -236,9 +303,15 @@
       "required": [],
       "properties": {
         "third_party": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
-          "required": ["relation", "make_primary"],
+          "required": [
+            "relation",
+            "make_primary"
+          ],
           "properties": {
             "relation": {
               "type": "string",
@@ -331,7 +404,12 @@
       "title": "Lodging",
       "type": "object",
       "additionalProperties": false,
-      "required": ["check_in", "check_out", "items", "location"],
+      "required": [
+        "check_in",
+        "check_out",
+        "items",
+        "location"
+      ],
       "properties": {
         "check_in": {
           "type": "integer"
@@ -350,10 +428,16 @@
           }
         },
         "room": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "guests": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -367,7 +451,9 @@
       "title": "Org",
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -385,18 +471,30 @@
           ]
         },
         "legal_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "logo": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri"
         },
         "website": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "hostname"
         },
         "vat_number": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "address": {
           "oneOf": [
@@ -417,10 +515,16 @@
       "required": [],
       "properties": {
         "street_address": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "city": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "region": {
           "oneOf": [
@@ -447,7 +551,10 @@
           ]
         },
         "postal_code": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lat": {
           "oneOf": [
@@ -474,29 +581,49 @@
           ]
         },
         "tz": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
     "person": {
       "title": "Person",
       "type": "object",
-      "required": ["metadata"],
+      "required": [
+        "metadata"
+      ],
       "properties": {
         "first_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "preferred_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "email": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -513,7 +640,10 @@
       "required": [],
       "properties": {
         "name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "address": {
           "oneOf": [
@@ -526,7 +656,10 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "url": {
           "oneOf": [
@@ -540,7 +673,10 @@
           ]
         },
         "google_place_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "image": {
           "oneOf": [
@@ -559,7 +695,10 @@
       "title": "Metadatum",
       "type": "object",
       "additionalProperties": false,
-      "required": ["key", "value"],
+      "required": [
+        "key",
+        "value"
+      ],
       "properties": {
         "key": {
           "type": "string"
@@ -573,7 +712,9 @@
       "title": "TransitRoute",
       "type": "object",
       "additionalProperties": false,
-      "required": ["transit_route_items"],
+      "required": [
+        "transit_route_items"
+      ],
       "properties": {
         "transit_route_items": {
           "type": "array",
@@ -588,7 +729,9 @@
       "title": "TransitRouteItem",
       "type": "object",
       "additionalProperties": false,
-      "required": ["metadata"],
+      "required": [
+        "metadata"
+      ],
       "properties": {
         "departure_location": {
           "oneOf": [
@@ -611,10 +754,16 @@
           ]
         },
         "departure_at": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "arrival_at": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "polyline": {
           "oneOf": [
@@ -649,7 +798,14 @@
             },
             {
               "type": "string",
-              "enum": ["car", "taxi", "rail", "bus", "ferry", "other"]
+              "enum": [
+                "car",
+                "taxi",
+                "rail",
+                "bus",
+                "ferry",
+                "other"
+              ]
             }
           ]
         }
@@ -659,7 +815,9 @@
       "title": "Item",
       "type": "object",
       "additionalProperties": false,
-      "required": ["description"],
+      "required": [
+        "description"
+      ],
       "properties": {
         "date": {
           "oneOf": [
@@ -676,10 +834,16 @@
           "type": "string"
         },
         "quantity": {
-          "type": ["null", "number"]
+          "type": [
+            "null",
+            "number"
+          ]
         },
         "unit": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "unspsc": {
           "oneOf": [
@@ -709,7 +873,10 @@
           ]
         },
         "group": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "url": {
           "oneOf": [
@@ -728,7 +895,10 @@
       "title": "Doc",
       "type": "object",
       "additionalProperties": false,
-      "required": ["title", "body"],
+      "required": [
+        "title",
+        "body"
+      ],
       "properties": {
         "title": {
           "type": "string"
@@ -745,7 +915,10 @@
       "required": [],
       "properties": {
         "supplemental_text": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -493,7 +493,7 @@
         "last_name": {
           "type": ["string", "null"]
         },
-        "preferred_name": {
+        "preferred_first_name": {
           "type": ["string", "null"]
         },
         "email": {

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -55,7 +55,7 @@
         },
         "vehicle": {
           "type": ["object", "null"],
-          "required": ["description", "image"],
+          "required": ["description"],
           "properties": {
             "description": {
               "type": "string"

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -212,13 +212,14 @@
           "type": ["null", "string"]
         },
         "passenger": {
-          "type": ["null", "string"]
-        },
-        "metadata": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/metadatum"
-          }
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/person"
+            }
+          ]
         }
       }
     },
@@ -471,6 +472,34 @@
         }
       }
     },
+    "person": {
+      "title": "Person",
+      "type": "object",
+      "required": ["metadata"],
+      "properties": {
+        "first_name": {
+          "type": ["string", "null"]
+        },
+        "last_name": {
+          "type": ["string", "null"]
+        },
+        "preferred_name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "phone": {
+          "type": ["string", "null"]
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/metadatum"
+          }
+        }
+      }
+    },
     "place": {
       "title": "Place",
       "description": "The physical or online location where a transaction occurred",
@@ -598,7 +627,14 @@
           }
         },
         "passenger": {
-          "type": ["string", "null"]
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/person"
+            }
+          ]
         },
         "mode": {
           "oneOf": [

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -111,6 +111,10 @@
           "minLength": 6,
           "maxLength": 127
         },
+        "website": {
+          "type": ["string", "null"],
+          "format": "hostname"
+        },
         "address": {
           "oneOf": [
             {

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -60,6 +60,12 @@
             "description": {
               "type": "string"
             },
+            "license_plate_number": {
+              "type": ["string", "null"]
+            },
+            "vehicle_class": {
+              "type": ["string", "null"]
+            },
             "image": {
               "type": ["string", "null"],
               "format": "uri"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -657,14 +657,7 @@
       "title": "Place",
       "description": "The physical or online location where a transaction occurred",
       "type": "object",
-      "required": [
-        "name",
-        "address",
-        "phone",
-        "url",
-        "google_place_id",
-        "image"
-      ],
+      "required": [],
       "properties": {
         "name": {
           "type": ["string", "null"]

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -247,7 +247,7 @@
     "flight_ticket": {
       "title": "FlightTicket",
       "type": "object",
-      "required": ["segments", "metadata", "taxes"],
+      "required": ["segments", "taxes"],
       "properties": {
         "segments": {
           "type": "array",

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -5,13 +5,7 @@
   "description": "A Versa itemized receipt",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "schema_version",
-    "header",
-    "itemization",
-    "payments",
-    "footer"
-  ],
+  "required": ["schema_version", "header", "itemization", "payments", "footer"],
   "properties": {
     "schema_version": {
       "title": "SchemaVersion",
@@ -40,10 +34,7 @@
     "action": {
       "title": "Action",
       "type": "object",
-      "required": [
-        "name",
-        "url"
-      ],
+      "required": ["name", "url"],
       "properties": {
         "name": {
           "type": "string"
@@ -83,35 +74,20 @@
           "$ref": "#/$defs/place"
         },
         "vehicle": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "description",
-            "image"
-          ],
+          "type": ["object", "null"],
+          "required": ["description", "image"],
           "properties": {
             "description": {
               "type": "string"
             },
             "license_plate_number": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vehicle_class": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "image": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "format": "uri"
             }
           }
@@ -149,19 +125,13 @@
     "customer": {
       "title": "Customer",
       "type": "object",
-      "required": [
-        "name",
-        "metadata"
-      ],
+      "required": ["name", "metadata"],
       "properties": {
         "name": {
           "type": "string"
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
           "maxLength": 127
@@ -177,10 +147,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "metadata": {
           "type": "array",
@@ -193,10 +160,7 @@
     "flight": {
       "title": "Flight",
       "type": "object",
-      "required": [
-        "tickets",
-        "invoice_level_adjustments"
-      ],
+      "required": ["tickets", "invoice_level_adjustments"],
       "properties": {
         "tickets": {
           "type": "array",
@@ -206,10 +170,7 @@
           }
         },
         "itinerary_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "invoice_level_adjustments": {
           "type": "array",
@@ -231,10 +192,7 @@
       ],
       "properties": {
         "fare": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "departure_airport_code": {
           "type": "string"
@@ -243,52 +201,28 @@
           "type": "string"
         },
         "aircraft_type": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "departure_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "arrival_at": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "departure_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "arrival_tz": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "flight_number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "seat": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "class_of_service": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "taxes": {
           "type": "array",
@@ -310,14 +244,10 @@
         }
       }
     },
-
     "flight_ticket": {
       "title": "FlightTicket",
       "type": "object",
-      "required": [
-        "segments",
-        "taxes"
-      ],
+      "required": ["segments", "taxes"],
       "properties": {
         "segments": {
           "type": "array",
@@ -328,22 +258,13 @@
         },
         "fare": {
           "description": "Total fare for the ticket; should be used *only* if the fare is not broken down by segment",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "number": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "record_locator": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "passenger": {
           "oneOf": [
@@ -367,34 +288,16 @@
       "title": "Header",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "currency",
-        "total",
-        "subtotal",
-        "paid",
-        "invoiced_at"
-      ],
+      "required": ["currency", "total", "subtotal", "paid", "invoiced_at"],
       "properties": {
         "invoice_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "currency": {
           "title": "Currency",
           "description": "ISO 4217 currency code",
           "type": "string",
-          "enum": [
-            "usd",
-            "eur",
-            "jpy",
-            "gbp",
-            "aud",
-            "cad",
-            "chf",
-            "cny"
-          ]
+          "enum": ["usd", "eur", "jpy", "gbp", "aud", "cad", "chf", "cny"]
         },
         "total": {
           "type": "integer"
@@ -409,21 +312,12 @@
           "type": "integer"
         },
         "mcc": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "third_party": {
-          "type": [
-            "object",
-            "null"
-          ],
+          "type": ["object", "null"],
           "additionalProperties": false,
-          "required": [
-            "relation",
-            "make_primary"
-          ],
+          "required": ["relation", "make_primary"],
           "properties": {
             "relation": {
               "type": "string",
@@ -473,16 +367,10 @@
           ]
         },
         "invoice_asset_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "receipt_asset_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     },
@@ -595,10 +483,7 @@
     "general_itemization": {
       "title": "GeneralItemization",
       "type": "object",
-      "required": [
-        "items",
-        "invoice_level_adjustments"
-      ],
+      "required": ["items", "invoice_level_adjustments"],
       "properties": {
         "items": {
           "type": "array",
@@ -643,16 +528,10 @@
           }
         },
         "room": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "guests": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "metadata": {
           "type": "array",
@@ -671,9 +550,7 @@
     "org": {
       "title": "Org",
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"
@@ -691,30 +568,18 @@
           ]
         },
         "legal_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "logo": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "uri"
         },
         "website": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "format": "hostname"
         },
         "vat_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -734,16 +599,10 @@
       "required": [],
       "properties": {
         "street_address": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "city": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "region": {
           "oneOf": [
@@ -770,10 +629,7 @@
           ]
         },
         "postal_code": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "lat": {
           "oneOf": [
@@ -800,49 +656,29 @@
           ]
         },
         "tz": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     },
     "person": {
       "title": "Person",
       "type": "object",
-      "required": [
-        "metadata"
-      ],
+      "required": ["metadata"],
       "properties": {
         "first_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "last_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "preferred_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "email": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "metadata": {
           "type": "array",
@@ -859,10 +695,7 @@
       "required": [],
       "properties": {
         "name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "address": {
           "oneOf": [
@@ -875,10 +708,7 @@
           ]
         },
         "phone": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "url": {
           "oneOf": [
@@ -892,10 +722,7 @@
           ]
         },
         "google_place_id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "image": {
           "oneOf": [
@@ -928,10 +755,7 @@
         "subscription_type": {
           "title": "SubscriptionType",
           "type": "string",
-          "enum": [
-            "one_time",
-            "recurring"
-          ]
+          "enum": ["one_time", "recurring"]
         },
         "description": {
           "type": "string"
@@ -944,44 +768,24 @@
             {
               "title": "Interval",
               "type": "string",
-              "enum": [
-                "day",
-                "week",
-                "month",
-                "year"
-              ]
+              "enum": ["day", "week", "month", "year"]
             }
           ]
         },
         "interval_count": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "current_period_start": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "current_period_end": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "quantity": {
-          "type": [
-            "number",
-            "null"
-          ]
+          "type": ["number", "null"]
         },
         "unit_cost": {
-          "type": [
-            "number",
-            "null"
-          ]
+          "type": ["number", "null"]
         },
         "taxes": {
           "type": "array",
@@ -1006,10 +810,7 @@
     "metadatum": {
       "title": "Metadatum",
       "type": "object",
-      "required": [
-        "key",
-        "value"
-      ],
+      "required": ["key", "value"],
       "properties": {
         "key": {
           "type": "string"
@@ -1022,45 +823,28 @@
     "adjustment": {
       "title": "Adjustment",
       "type": "object",
-      "required": [
-        "amount",
-        "adjustment_type"
-      ],
+      "required": ["amount", "adjustment_type"],
       "properties": {
         "amount": {
           "type": "integer"
         },
         "name": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "adjustment_type": {
           "title": "AdjustmentType",
           "type": "string",
-          "enum": [
-            "add_on",
-            "discount",
-            "fee",
-            "other",
-            "tip"
-          ]
+          "enum": ["add_on", "discount", "fee", "other", "tip"]
         },
         "rate": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         }
       }
     },
     "shipment": {
       "title": "Shipment",
       "type": "object",
-      "required": [
-        "items"
-      ],
+      "required": ["items"],
       "properties": {
         "items": {
           "type": "array",
@@ -1070,16 +854,10 @@
           }
         },
         "tracking_number": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "expected_delivery_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "shipment_status": {
           "oneOf": [
@@ -1088,11 +866,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "prep",
-                "in_transit",
-                "delivered"
-              ]
+              "enum": ["prep", "in_transit", "delivered"]
             }
           ]
         },
@@ -1111,10 +885,7 @@
     "subscription": {
       "title": "Subscription",
       "type": "object",
-      "required": [
-        "subscription_items",
-        "invoice_level_adjustments"
-      ],
+      "required": ["subscription_items", "invoice_level_adjustments"],
       "properties": {
         "subscription_items": {
           "type": "array",
@@ -1134,20 +905,13 @@
     "tax": {
       "title": "Tax",
       "type": "object",
-      "required": [
-        "amount",
-        "rate",
-        "name"
-      ],
+      "required": ["amount", "rate", "name"],
       "properties": {
         "amount": {
           "type": "integer"
         },
         "rate": {
-          "type": [
-            "number",
-            "null"
-          ]
+          "type": ["number", "null"]
         },
         "name": {
           "type": "string"
@@ -1157,10 +921,7 @@
     "transit_route": {
       "title": "TransitRoute",
       "type": "object",
-      "required": [
-        "transit_route_items",
-        "invoice_level_adjustments"
-      ],
+      "required": ["transit_route_items", "invoice_level_adjustments"],
       "properties": {
         "transit_route_items": {
           "type": "array",
@@ -1180,12 +941,7 @@
     "transit_route_item": {
       "title": "TransitRouteItem",
       "type": "object",
-      "required": [
-        "fare",
-        "taxes",
-        "metadata",
-        "adjustments"
-      ],
+      "required": ["fare", "taxes", "metadata", "adjustments"],
       "properties": {
         "departure_location": {
           "oneOf": [
@@ -1208,16 +964,10 @@
           ]
         },
         "departure_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "arrival_at": {
-          "type": [
-            "integer",
-            "null"
-          ]
+          "type": ["integer", "null"]
         },
         "polyline": {
           "oneOf": [
@@ -1248,9 +998,7 @@
           }
         },
         "fare": {
-          "type": [
-            "integer"
-          ]
+          "type": ["integer"]
         },
         "passenger": {
           "oneOf": [
@@ -1269,14 +1017,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "car",
-                "taxi",
-                "rail",
-                "bus",
-                "ferry",
-                "other"
-              ]
+              "enum": ["car", "taxi", "rail", "bus", "ferry", "other"]
             }
           ]
         }
@@ -1285,10 +1026,7 @@
     "item": {
       "title": "Item",
       "type": "object",
-      "required": [
-        "description",
-        "amount"
-      ],
+      "required": ["description", "amount"],
       "properties": {
         "date": {
           "oneOf": [
@@ -1308,22 +1046,13 @@
           "type": "integer"
         },
         "quantity": {
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "unit_cost": {
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "unit": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "unspsc": {
           "oneOf": [
@@ -1359,10 +1088,7 @@
           ]
         },
         "group": {
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "url": {
           "oneOf": [
@@ -1386,10 +1112,7 @@
     "payment": {
       "title": "Payment",
       "type": "object",
-      "required": [
-        "amount",
-        "paid_at"
-      ],
+      "required": ["amount", "paid_at"],
       "properties": {
         "amount": {
           "type": "integer"
@@ -1404,10 +1127,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "card",
-                "ach"
-              ]
+              "enum": ["card", "ach"]
             }
           ]
         },
@@ -1436,9 +1156,7 @@
     "card_payment": {
       "title": "CardPayment",
       "type": "object",
-      "required": [
-        "last_four"
-      ],
+      "required": ["last_four"],
       "properties": {
         "last_four": {
           "type": "string"
@@ -1468,9 +1186,7 @@
     "ach_payment": {
       "title": "AchPayment",
       "type": "object",
-      "required": [
-        "routing_number"
-      ],
+      "required": ["routing_number"],
       "properties": {
         "routing_number": {
           "type": "string"
@@ -1480,10 +1196,7 @@
     "doc": {
       "title": "Doc",
       "type": "object",
-      "required": [
-        "title",
-        "body"
-      ],
+      "required": ["title", "body"],
       "properties": {
         "title": {
           "type": "string"
@@ -1496,9 +1209,7 @@
     "footer": {
       "title": "Footer",
       "type": "object",
-      "required": [
-        "actions"
-      ],
+      "required": ["actions"],
       "properties": {
         "actions": {
           "type": "array",
@@ -1507,10 +1218,7 @@
           }
         },
         "supplemental_text": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     }

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -675,7 +675,7 @@
         "last_name": {
           "type": ["string", "null"]
         },
-        "preferred_name": {
+        "preferred_first_name": {
           "type": ["string", "null"]
         },
         "email": {

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -5,7 +5,13 @@
   "description": "A Versa itemized receipt",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "header", "itemization", "payments", "footer"],
+  "required": [
+    "schema_version",
+    "header",
+    "itemization",
+    "payments",
+    "footer"
+  ],
   "properties": {
     "schema_version": {
       "title": "SchemaVersion",
@@ -34,7 +40,10 @@
     "action": {
       "title": "Action",
       "type": "object",
-      "required": ["name", "url"],
+      "required": [
+        "name",
+        "url"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -74,20 +83,35 @@
           "$ref": "#/$defs/place"
         },
         "vehicle": {
-          "type": ["object", "null"],
-          "required": ["description", "image"],
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "description",
+            "image"
+          ],
           "properties": {
             "description": {
               "type": "string"
             },
             "license_plate_number": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vehicle_class": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "image": {
-              "type": ["string", "null"],
+              "type": [
+                "string",
+                "null"
+              ],
               "format": "uri"
             }
           }
@@ -125,13 +149,19 @@
     "customer": {
       "title": "Customer",
       "type": "object",
-      "required": ["name", "metadata"],
+      "required": [
+        "name",
+        "metadata"
+      ],
       "properties": {
         "name": {
           "type": "string"
         },
         "email": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "email",
           "minLength": 6,
           "maxLength": 127
@@ -147,7 +177,10 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -160,7 +193,10 @@
     "flight": {
       "title": "Flight",
       "type": "object",
-      "required": ["tickets", "invoice_level_adjustments"],
+      "required": [
+        "tickets",
+        "invoice_level_adjustments"
+      ],
       "properties": {
         "tickets": {
           "type": "array",
@@ -170,7 +206,10 @@
           }
         },
         "itinerary_locator": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "invoice_level_adjustments": {
           "type": "array",
@@ -192,7 +231,10 @@
       ],
       "properties": {
         "fare": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "departure_airport_code": {
           "type": "string"
@@ -201,28 +243,52 @@
           "type": "string"
         },
         "aircraft_type": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "departure_at": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "arrival_at": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "departure_tz": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "arrival_tz": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "flight_number": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "seat": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "class_of_service": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "taxes": {
           "type": "array",
@@ -244,10 +310,14 @@
         }
       }
     },
+
     "flight_ticket": {
       "title": "FlightTicket",
       "type": "object",
-      "required": ["segments", "taxes"],
+      "required": [
+        "segments",
+        "taxes"
+      ],
       "properties": {
         "segments": {
           "type": "array",
@@ -258,13 +328,22 @@
         },
         "fare": {
           "description": "Total fare for the ticket; should be used *only* if the fare is not broken down by segment",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "number": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "record_locator": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "passenger": {
           "oneOf": [
@@ -288,16 +367,34 @@
       "title": "Header",
       "type": "object",
       "additionalProperties": false,
-      "required": ["currency", "total", "subtotal", "paid", "invoiced_at"],
+      "required": [
+        "currency",
+        "total",
+        "subtotal",
+        "paid",
+        "invoiced_at"
+      ],
       "properties": {
         "invoice_number": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "currency": {
           "title": "Currency",
           "description": "ISO 4217 currency code",
           "type": "string",
-          "enum": ["usd", "eur", "jpy", "gbp", "aud", "cad", "chf", "cny"]
+          "enum": [
+            "usd",
+            "eur",
+            "jpy",
+            "gbp",
+            "aud",
+            "cad",
+            "chf",
+            "cny"
+          ]
         },
         "total": {
           "type": "integer"
@@ -312,12 +409,21 @@
           "type": "integer"
         },
         "mcc": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "third_party": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
-          "required": ["relation", "make_primary"],
+          "required": [
+            "relation",
+            "make_primary"
+          ],
           "properties": {
             "relation": {
               "type": "string",
@@ -367,10 +473,16 @@
           ]
         },
         "invoice_asset_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "receipt_asset_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
@@ -483,7 +595,10 @@
     "general_itemization": {
       "title": "GeneralItemization",
       "type": "object",
-      "required": ["items", "invoice_level_adjustments"],
+      "required": [
+        "items",
+        "invoice_level_adjustments"
+      ],
       "properties": {
         "items": {
           "type": "array",
@@ -528,10 +643,16 @@
           }
         },
         "room": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "guests": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -550,7 +671,9 @@
     "org": {
       "title": "Org",
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -568,18 +691,30 @@
           ]
         },
         "legal_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "logo": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "uri"
         },
         "website": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "hostname"
         },
         "vat_number": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "address": {
           "oneOf": [
@@ -599,10 +734,16 @@
       "required": [],
       "properties": {
         "street_address": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "city": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "region": {
           "oneOf": [
@@ -629,7 +770,10 @@
           ]
         },
         "postal_code": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lat": {
           "oneOf": [
@@ -656,29 +800,49 @@
           ]
         },
         "tz": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
     "person": {
       "title": "Person",
       "type": "object",
-      "required": ["metadata"],
+      "required": [
+        "metadata"
+      ],
       "properties": {
         "first_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "preferred_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "email": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "metadata": {
           "type": "array",
@@ -695,7 +859,10 @@
       "required": [],
       "properties": {
         "name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "address": {
           "oneOf": [
@@ -708,7 +875,10 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "url": {
           "oneOf": [
@@ -722,7 +892,10 @@
           ]
         },
         "google_place_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "image": {
           "oneOf": [
@@ -755,7 +928,10 @@
         "subscription_type": {
           "title": "SubscriptionType",
           "type": "string",
-          "enum": ["one_time", "recurring"]
+          "enum": [
+            "one_time",
+            "recurring"
+          ]
         },
         "description": {
           "type": "string"
@@ -768,24 +944,44 @@
             {
               "title": "Interval",
               "type": "string",
-              "enum": ["day", "week", "month", "year"]
+              "enum": [
+                "day",
+                "week",
+                "month",
+                "year"
+              ]
             }
           ]
         },
         "interval_count": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "current_period_start": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "current_period_end": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "quantity": {
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "unit_cost": {
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "taxes": {
           "type": "array",
@@ -810,7 +1006,10 @@
     "metadatum": {
       "title": "Metadatum",
       "type": "object",
-      "required": ["key", "value"],
+      "required": [
+        "key",
+        "value"
+      ],
       "properties": {
         "key": {
           "type": "string"
@@ -823,28 +1022,45 @@
     "adjustment": {
       "title": "Adjustment",
       "type": "object",
-      "required": ["amount", "adjustment_type"],
+      "required": [
+        "amount",
+        "adjustment_type"
+      ],
       "properties": {
         "amount": {
           "type": "integer"
         },
         "name": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "adjustment_type": {
           "title": "AdjustmentType",
           "type": "string",
-          "enum": ["add_on", "discount", "fee", "other", "tip"]
+          "enum": [
+            "add_on",
+            "discount",
+            "fee",
+            "other",
+            "tip"
+          ]
         },
         "rate": {
-          "type": ["null", "number"]
+          "type": [
+            "null",
+            "number"
+          ]
         }
       }
     },
     "shipment": {
       "title": "Shipment",
       "type": "object",
-      "required": ["items"],
+      "required": [
+        "items"
+      ],
       "properties": {
         "items": {
           "type": "array",
@@ -854,10 +1070,16 @@
           }
         },
         "tracking_number": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "expected_delivery_at": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "shipment_status": {
           "oneOf": [
@@ -866,7 +1088,11 @@
             },
             {
               "type": "string",
-              "enum": ["prep", "in_transit", "delivered"]
+              "enum": [
+                "prep",
+                "in_transit",
+                "delivered"
+              ]
             }
           ]
         },
@@ -885,7 +1111,10 @@
     "subscription": {
       "title": "Subscription",
       "type": "object",
-      "required": ["subscription_items", "invoice_level_adjustments"],
+      "required": [
+        "subscription_items",
+        "invoice_level_adjustments"
+      ],
       "properties": {
         "subscription_items": {
           "type": "array",
@@ -905,13 +1134,20 @@
     "tax": {
       "title": "Tax",
       "type": "object",
-      "required": ["amount", "rate", "name"],
+      "required": [
+        "amount",
+        "rate",
+        "name"
+      ],
       "properties": {
         "amount": {
           "type": "integer"
         },
         "rate": {
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "name": {
           "type": "string"
@@ -921,7 +1157,10 @@
     "transit_route": {
       "title": "TransitRoute",
       "type": "object",
-      "required": ["transit_route_items", "invoice_level_adjustments"],
+      "required": [
+        "transit_route_items",
+        "invoice_level_adjustments"
+      ],
       "properties": {
         "transit_route_items": {
           "type": "array",
@@ -941,7 +1180,12 @@
     "transit_route_item": {
       "title": "TransitRouteItem",
       "type": "object",
-      "required": ["fare", "taxes", "metadata", "adjustments"],
+      "required": [
+        "fare",
+        "taxes",
+        "metadata",
+        "adjustments"
+      ],
       "properties": {
         "departure_location": {
           "oneOf": [
@@ -964,10 +1208,16 @@
           ]
         },
         "departure_at": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "arrival_at": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "polyline": {
           "oneOf": [
@@ -998,7 +1248,9 @@
           }
         },
         "fare": {
-          "type": ["integer"]
+          "type": [
+            "integer"
+          ]
         },
         "passenger": {
           "oneOf": [
@@ -1017,7 +1269,14 @@
             },
             {
               "type": "string",
-              "enum": ["car", "taxi", "rail", "bus", "ferry", "other"]
+              "enum": [
+                "car",
+                "taxi",
+                "rail",
+                "bus",
+                "ferry",
+                "other"
+              ]
             }
           ]
         }
@@ -1026,7 +1285,10 @@
     "item": {
       "title": "Item",
       "type": "object",
-      "required": ["description", "amount"],
+      "required": [
+        "description",
+        "amount"
+      ],
       "properties": {
         "date": {
           "oneOf": [
@@ -1046,13 +1308,22 @@
           "type": "integer"
         },
         "quantity": {
-          "type": ["null", "number"]
+          "type": [
+            "null",
+            "number"
+          ]
         },
         "unit_cost": {
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "unit": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "unspsc": {
           "oneOf": [
@@ -1088,7 +1359,10 @@
           ]
         },
         "group": {
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "url": {
           "oneOf": [
@@ -1112,7 +1386,10 @@
     "payment": {
       "title": "Payment",
       "type": "object",
-      "required": ["amount", "paid_at"],
+      "required": [
+        "amount",
+        "paid_at"
+      ],
       "properties": {
         "amount": {
           "type": "integer"
@@ -1127,7 +1404,10 @@
             },
             {
               "type": "string",
-              "enum": ["card", "ach"]
+              "enum": [
+                "card",
+                "ach"
+              ]
             }
           ]
         },
@@ -1156,7 +1436,9 @@
     "card_payment": {
       "title": "CardPayment",
       "type": "object",
-      "required": ["last_four"],
+      "required": [
+        "last_four"
+      ],
       "properties": {
         "last_four": {
           "type": "string"
@@ -1186,7 +1468,9 @@
     "ach_payment": {
       "title": "AchPayment",
       "type": "object",
-      "required": ["routing_number"],
+      "required": [
+        "routing_number"
+      ],
       "properties": {
         "routing_number": {
           "type": "string"
@@ -1196,7 +1480,10 @@
     "doc": {
       "title": "Doc",
       "type": "object",
-      "required": ["title", "body"],
+      "required": [
+        "title",
+        "body"
+      ],
       "properties": {
         "title": {
           "type": "string"
@@ -1209,7 +1496,9 @@
     "footer": {
       "title": "Footer",
       "type": "object",
-      "required": ["actions"],
+      "required": [
+        "actions"
+      ],
       "properties": {
         "actions": {
           "type": "array",
@@ -1218,7 +1507,10 @@
           }
         },
         "supplemental_text": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -75,7 +75,7 @@
         },
         "vehicle": {
           "type": ["object", "null"],
-          "required": ["description", "image"],
+          "required": ["description"],
           "properties": {
             "description": {
               "type": "string"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -261,18 +261,19 @@
           "type": ["null", "string"]
         },
         "passenger": {
-          "type": ["null", "string"]
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/person"
+            }
+          ]
         },
         "taxes": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/tax"
-          }
-        },
-        "metadata": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/metadatum"
           }
         }
       }
@@ -653,6 +654,34 @@
         }
       }
     },
+    "person": {
+      "title": "Person",
+      "type": "object",
+      "required": ["metadata"],
+      "properties": {
+        "first_name": {
+          "type": ["string", "null"]
+        },
+        "last_name": {
+          "type": ["string", "null"]
+        },
+        "preferred_name": {
+          "type": ["string", "null"]
+        },
+        "email": {
+          "type": ["string", "null"]
+        },
+        "phone": {
+          "type": ["string", "null"]
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/metadatum"
+          }
+        }
+      }
+    },
     "place": {
       "title": "Place",
       "description": "The physical or online location where a transaction occurred",
@@ -799,7 +828,7 @@
         "adjustment_type": {
           "title": "AdjustmentType",
           "type": "string",
-          "enum": ["discount", "tip", "fee", "other"]
+          "enum": ["add_on", "discount", "fee", "other", "tip"]
         },
         "rate": {
           "type": ["null", "number"]
@@ -966,7 +995,14 @@
           "type": ["integer"]
         },
         "passenger": {
-          "type": ["string", "null"]
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/person"
+            }
+          ]
         },
         "mode": {
           "oneOf": [

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -290,7 +290,7 @@
           "title": "Currency",
           "description": "ISO 4217 currency code",
           "type": "string",
-          "enum": ["usd", "eur", "jpy", "gbp", "aud", "cad", "chf", "cnh"]
+          "enum": ["usd", "eur", "jpy", "gbp", "aud", "cad", "chf", "cny"]
         },
         "total": {
           "type": "integer"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -80,6 +80,12 @@
             "description": {
               "type": "string"
             },
+            "license_plate_number": {
+              "type": ["string", "null"]
+            },
+            "vehicle_class": {
+              "type": ["string", "null"]
+            },
             "image": {
               "type": ["string", "null"],
               "format": "uri"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -136,6 +136,10 @@
           "minLength": 6,
           "maxLength": 127
         },
+        "website": {
+          "type": ["string", "null"],
+          "format": "hostname"
+        },
         "address": {
           "oneOf": [
             {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "husky",
-    "pre-commit": "lint-staged",
+    "pre-commit": "lint-staged && pnpm verify_subschema",
     "verify_subschema": "ts-node ./scripts/verify_subschema.ts"
   },
   "lint-staged": {


### PR DESCRIPTION
**Breaking Changes**
- `passenger` changes from type `["string", "null"]` to a nullable `Person` object
- `metadata` is removed from `flight_ticket`

**Other Changes**
- FIX: `place` nullable fields should also not be required
- FIX: `currency` should support `"cny"` instead of `"cnh"`
- Added to rental car `vehicle`
  - license_plate_number (string)
  - vehicle_class (ACRISS car code, four letters)
- Added adjustment type enum option: `"add_on"`
