### PR TITLE
feat: 2.0.0-rc2 with regex patterns

### DIFF
--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -42,10 +42,14 @@
       ],
       "properties": {
         "rental_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "return_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "rental_location": {
           "$ref": "#/$defs/place"
@@ -176,13 +180,18 @@
           "pattern": "^[a-zA-Z]{3}$"
         },
         "aircraft_type": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[a-zA-Z0-9]{2,4}$"
         },
         "departure_at": {
-          "type": ["null", "integer"]
+          "type": ["null", "integer"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "arrival_at": {
-          "type": ["null", "integer"]
+          "type": ["null", "integer"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "departure_tz": {
           "type": ["null", "string"]
@@ -362,7 +371,10 @@
           "type": ["null", "string"]
         },
         "guests": {
-          "type": ["null", "string"]
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/person"
+          }
         },
         "metadata": {
           "type": "array",
@@ -495,7 +507,10 @@
           "type": ["string", "null"]
         },
         "email": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "format": "email",
+          "minLength": 6,
+          "maxLength": 127
         },
         "phone": {
           "type": ["string", "null"],
@@ -616,10 +631,14 @@
           ]
         },
         "departure_at": {
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "arrival_at": {
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "polyline": {
           "oneOf": [

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -383,7 +383,7 @@
         },
         "brand_color": {
           "description": "Hex color",
-          "type": "string",
+          "type": ["string", "null"],
           "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
         },
         "legal_name": {

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -66,7 +66,7 @@
             },
             "vehicle_class": {
               "type": ["string", "null"],
-              "pattern": "^[A-Z]{4}$"
+              "pattern": "^[a-zA-Z]{4}$"
             },
             "image": {
               "type": ["string", "null"],
@@ -169,11 +169,11 @@
       "properties": {
         "departure_airport_code": {
           "type": "string",
-          "pattern": "^[A-Z]{3}$"
+          "pattern": "^[a-zA-Z]{3}$"
         },
         "arrival_airport_code": {
           "type": "string",
-          "pattern": "^[A-Z]{3}$"
+          "pattern": "^[a-zA-Z]{3}$"
         },
         "aircraft_type": {
           "type": ["null", "string"]
@@ -191,8 +191,7 @@
           "type": ["null", "string"]
         },
         "flight_number": {
-          "type": ["null", "string"],
-          "pattern": "^[A-Z]{2,3}\\d{1,4}$"
+          "type": ["null", "string"]
         },
         "seat": {
           "type": ["null", "string"]
@@ -383,16 +382,9 @@
           "type": "string"
         },
         "brand_color": {
-          "oneOf": [
-            {
-              "description": "Hex color",
-              "type": "string",
-              "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "description": "Hex color",
+          "type": "string",
+          "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
         },
         "legal_name": {
           "type": ["string", "null"]
@@ -439,8 +431,7 @@
             },
             {
               "type": "string",
-              "minLength": 2,
-              "maxLength": 2
+              "pattern": "^[a-zA-Z0-9]{1,3}$"
             }
           ]
         },

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -44,12 +44,12 @@
         "rental_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "return_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "rental_location": {
           "$ref": "#/$defs/place"
@@ -186,12 +186,12 @@
         "departure_at": {
           "type": ["null", "integer"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "arrival_at": {
           "type": ["null", "integer"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "departure_tz": {
           "type": ["null", "string"]
@@ -633,12 +633,12 @@
         "departure_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "arrival_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "polyline": {
           "oneOf": [

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -65,7 +65,8 @@
               "type": ["string", "null"]
             },
             "vehicle_class": {
-              "type": ["string", "null"]
+              "type": ["string", "null"],
+              "pattern": "^[A-Z]{4}$"
             },
             "image": {
               "type": ["string", "null"],
@@ -127,7 +128,8 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "metadata": {
           "type": "array",
@@ -166,10 +168,12 @@
       ],
       "properties": {
         "departure_airport_code": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
         },
         "arrival_airport_code": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
         },
         "aircraft_type": {
           "type": ["null", "string"]
@@ -187,7 +191,8 @@
           "type": ["null", "string"]
         },
         "flight_number": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[A-Z]{2,3}\\d{1,4}$"
         },
         "seat": {
           "type": ["null", "string"]
@@ -502,7 +507,8 @@
           "type": ["string", "null"]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "metadata": {
           "type": "array",
@@ -533,7 +539,8 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "url": {
           "oneOf": [

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -115,7 +115,7 @@
           "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
-          "maxLength": 127
+          "maxLength": 254
         },
         "website": {
           "type": ["string", "null"],
@@ -510,7 +510,7 @@
           "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
-          "maxLength": 127
+          "maxLength": 254
         },
         "phone": {
           "type": ["string", "null"],

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -87,7 +87,8 @@
               "type": ["string", "null"]
             },
             "vehicle_class": {
-              "type": ["string", "null"]
+              "type": ["string", "null"],
+              "pattern": "^[A-Z]{4}$"
             },
             "image": {
               "type": ["string", "null"],
@@ -155,7 +156,8 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "metadata": {
           "type": "array",
@@ -179,7 +181,8 @@
           }
         },
         "itinerary_locator": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[A-Z0-9]{6}$"
         },
         "invoice_level_adjustments": {
           "type": "array",
@@ -205,10 +208,12 @@
           "type": ["null", "integer"]
         },
         "departure_airport_code": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
         },
         "arrival_airport_code": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
         },
         "aircraft_type": {
           "type": ["null", "string"]
@@ -226,7 +231,8 @@
           "type": ["null", "string"]
         },
         "flight_number": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[A-Z]{2,3}\\d{1,4}$"
         },
         "seat": {
           "type": ["null", "string"]
@@ -275,7 +281,8 @@
           "type": ["null", "string"]
         },
         "record_locator": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[A-Z0-9]{6}$"
         },
         "passenger": {
           "oneOf": [
@@ -323,7 +330,8 @@
           "type": "integer"
         },
         "mcc": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\d{4}$"
         },
         "third_party": {
           "type": ["object", "null"],
@@ -696,7 +704,8 @@
           "type": ["string", "null"]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "metadata": {
           "type": "array",
@@ -727,7 +736,8 @@
           ]
         },
         "phone": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^\\+?[1-9]\\d{1,14}$"
         },
         "url": {
           "oneOf": [
@@ -1189,7 +1199,8 @@
       "required": ["last_four"],
       "properties": {
         "last_four": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^\\d{4}$"
         },
         "network": {
           "oneOf": [
@@ -1220,7 +1231,8 @@
       "required": ["routing_number"],
       "properties": {
         "routing_number": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^\\d{9}$"
         }
       }
     },

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -143,7 +143,7 @@
           "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
-          "maxLength": 127
+          "maxLength": 254
         },
         "website": {
           "type": ["string", "null"],
@@ -707,7 +707,7 @@
           "type": ["string", "null"],
           "format": "email",
           "minLength": 6,
-          "maxLength": 127
+          "maxLength": 254
         },
         "phone": {
           "type": ["string", "null"],

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -64,10 +64,14 @@
       ],
       "properties": {
         "rental_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "return_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "rental_location": {
           "$ref": "#/$defs/place"
@@ -215,13 +219,18 @@
           "pattern": "^[a-zA-Z]{3}$"
         },
         "aircraft_type": {
-          "type": ["null", "string"]
+          "type": ["null", "string"],
+          "pattern": "^[a-zA-Z0-9]{2,4}$"
         },
         "departure_at": {
-          "type": ["null", "integer"]
+          "type": ["null", "integer"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "arrival_at": {
-          "type": ["null", "integer"]
+          "type": ["null", "integer"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "departure_tz": {
           "type": ["null", "string"]
@@ -324,7 +333,9 @@
           "type": "integer"
         },
         "invoiced_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "mcc": {
           "type": ["string", "null"],
@@ -551,7 +562,10 @@
           "type": ["null", "string"]
         },
         "guests": {
-          "type": ["null", "string"]
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/person"
+          }
         },
         "metadata": {
           "type": "array",
@@ -690,7 +704,10 @@
           "type": ["string", "null"]
         },
         "email": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "format": "email",
+          "minLength": 6,
+          "maxLength": 127
         },
         "phone": {
           "type": ["string", "null"],
@@ -794,11 +811,15 @@
         "interval_count": {
           "type": ["integer", "null"]
         },
-        "current_period_start": {
-          "type": ["integer", "null"]
+        "current_period_start_at": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
-        "current_period_end": {
-          "type": ["integer", "null"]
+        "current_period_end_at": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "quantity": {
           "type": ["number", "null"]
@@ -879,7 +900,9 @@
           "type": ["string", "null"]
         },
         "expected_delivery_at": {
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "shipment_status": {
           "oneOf": [
@@ -990,10 +1013,14 @@
           ]
         },
         "departure_at": {
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "arrival_at": {
-          "type": ["integer", "null"]
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "polyline": {
           "oneOf": [
@@ -1146,7 +1173,9 @@
           "type": "integer"
         },
         "paid_at": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3153600000
         },
         "payment_type": {
           "oneOf": [

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -66,12 +66,12 @@
         "rental_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "return_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "rental_location": {
           "$ref": "#/$defs/place"
@@ -225,12 +225,12 @@
         "departure_at": {
           "type": ["null", "integer"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "arrival_at": {
           "type": ["null", "integer"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "departure_tz": {
           "type": ["null", "string"]
@@ -335,7 +335,7 @@
         "invoiced_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "mcc": {
           "type": ["string", "null"],
@@ -814,12 +814,12 @@
         "current_period_start_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "current_period_end_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "quantity": {
           "type": ["number", "null"]
@@ -902,7 +902,7 @@
         "expected_delivery_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "shipment_status": {
           "oneOf": [
@@ -1015,12 +1015,12 @@
         "departure_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "arrival_at": {
           "type": ["integer", "null"],
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "polyline": {
           "oneOf": [
@@ -1175,7 +1175,7 @@
         "paid_at": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3153600000
+          "maximum": 4102462800
         },
         "payment_type": {
           "oneOf": [

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -576,10 +576,10 @@
         "name": {
           "type": "string"
         },
-        "brand_color":{
-              "description": "Hex color",
-              "type": ["string", "null"],
-              "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
+        "brand_color": {
+          "description": "Hex color",
+          "type": ["string", "null"],
+          "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
         },
         "legal_name": {
           "type": ["string", "null"]

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -88,7 +88,7 @@
             },
             "vehicle_class": {
               "type": ["string", "null"],
-              "pattern": "^[A-Z]{4}$"
+              "pattern": "^[a-zA-Z]{4}$"
             },
             "image": {
               "type": ["string", "null"],
@@ -181,8 +181,7 @@
           }
         },
         "itinerary_locator": {
-          "type": ["null", "string"],
-          "pattern": "^[A-Z0-9]{6}$"
+          "type": ["null", "string"]
         },
         "invoice_level_adjustments": {
           "type": "array",
@@ -209,11 +208,11 @@
         },
         "departure_airport_code": {
           "type": "string",
-          "pattern": "^[A-Z]{3}$"
+          "pattern": "^[a-zA-Z]{3}$"
         },
         "arrival_airport_code": {
           "type": "string",
-          "pattern": "^[A-Z]{3}$"
+          "pattern": "^[a-zA-Z]{3}$"
         },
         "aircraft_type": {
           "type": ["null", "string"]
@@ -231,8 +230,7 @@
           "type": ["null", "string"]
         },
         "flight_number": {
-          "type": ["null", "string"],
-          "pattern": "^[A-Z]{2,3}\\d{1,4}$"
+          "type": ["null", "string"]
         },
         "seat": {
           "type": ["null", "string"]
@@ -281,8 +279,7 @@
           "type": ["null", "string"]
         },
         "record_locator": {
-          "type": ["null", "string"],
-          "pattern": "^[A-Z0-9]{6}$"
+          "type": ["null", "string"]
         },
         "passenger": {
           "oneOf": [
@@ -579,17 +576,10 @@
         "name": {
           "type": "string"
         },
-        "brand_color": {
-          "oneOf": [
-            {
+        "brand_color":{
               "description": "Hex color",
-              "type": "string",
+              "type": ["string", "null"],
               "pattern": "^#?([a-f0-9]{6}|[a-f0-9]{3})$"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "legal_name": {
           "type": ["string", "null"]
@@ -636,8 +626,7 @@
             },
             {
               "type": "string",
-              "minLength": 2,
-              "maxLength": 2
+              "pattern": "^[a-zA-Z0-9]{1,3}$"
             }
           ]
         },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "prepare": "husky",
     "pre-commit": "lint-staged && pnpm verify_subschema",
+    "test": "pnpm verify_subschema",
     "verify_subschema": "ts-node ./scripts/verify_subschema.ts"
   },
   "lint-staged": {

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -15,7 +15,7 @@ export const isObjectSubset = (
         return false;
       }
     }
-    if (key === "pattern") {
+    if (key === "pattern" && !!subValue) {
       if (subValue !== superValue) {
         console.log("pattern mismatch", key, superValue, subValue);
         return false;

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -17,7 +17,13 @@ export const isObjectSubset = (
     }
     if (key === "pattern" && !!subValue) {
       if (subValue !== superValue) {
-        console.log("pattern mismatch", key, superValue, subValue);
+        console.log("pattern mismatch", superValue, subValue);
+        return false;
+      }
+    }
+    if (key === "type" && !!subValue) {
+      if (subValue.toString() !== superValue.toString()) {
+        console.log("type mismatch", superValue, subValue);
         return false;
       }
     }

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -1,6 +1,7 @@
 export const isObjectSubset = (
   subObject: object,
   superObject: object,
+  parentKey: string = "root",
   strict = false,
 ): boolean => {
   for (const key of Object.keys(subObject)) {
@@ -11,19 +12,28 @@ export const isObjectSubset = (
     const subValue = (subObject as any)[key];
     const superValue = (superObject as any)[key];
     if (typeof subValue === "object" && typeof superValue === "object") {
-      if (!isObjectSubset(subValue, superValue, strict)) {
+      if (!isObjectSubset(subValue, superValue, key, strict)) {
         return false;
       }
     }
-    if (key === "pattern" && !!subValue) {
-      if (subValue !== superValue) {
-        console.log("pattern mismatch", superValue, subValue);
+    // The following two clauses don't really belong here;
+    // generally this verification process should be improved to ensure
+    // all formatting patterns, mins, and maxes are uniform between schemas
+    if (key === "pattern") {
+      if (!!superValue && !subValue) {
+        console.log("pattern must always be defined for", parentKey);
+      }
+      if (!!subValue && subValue !== superValue) {
+        console.log("pattern mismatch for", parentKey, superValue, subValue);
         return false;
       }
     }
-    if (key === "type" && !!subValue) {
+    if (key === "type") {
+      if (!!superValue && !subValue) {
+        console.log("type must always be defined for", parentKey);
+      }
       if (subValue.toString() !== superValue.toString()) {
-        console.log("type mismatch", superValue, subValue);
+        console.log("type mismatch for", parentKey, superValue, subValue);
         return false;
       }
     }

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -15,6 +15,12 @@ export const isObjectSubset = (
         return false;
       }
     }
+    if (key === "pattern") {
+      if (subValue !== superValue) {
+        console.log("pattern mismatch", key, superValue, subValue);
+        return false;
+      }
+    }
   }
   return true;
 };


### PR DESCRIPTION
## Breaking Changes

- `guests` is now an array of `Person` objects
- `current_period_start` and `current_period_end` have been renamed `current_period_start_at` and `current_period_end_at`

## Additional Changes
- regex pattern validation for `vehicle_class`, `phone`, `routing_number`, `last_four` and airport codes
- minimum and maximum bounds for unix timestamps