### PR TITLE
2.1.1 Patch update

### DIFF
--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -34,7 +34,7 @@
         "return_at",
         "rental_location",
         "return_location",
-        "driver_name",
+        "drivers",
         "odometer_reading_in",
         "odometer_reading_out",
         "items"
@@ -77,8 +77,12 @@
             }
           }
         },
-        "driver_name": {
-          "type": "string"
+        "drivers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/person"
+          }
         },
         "odometer_reading_in": {
           "type": "integer"

--- a/data/itinerary.schema.json
+++ b/data/itinerary.schema.json
@@ -34,7 +34,6 @@
         "return_at",
         "rental_location",
         "return_location",
-        "drivers",
         "odometer_reading_in",
         "odometer_reading_out",
         "items"
@@ -78,11 +77,17 @@
           }
         },
         "drivers": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/person"
-          }
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/person"
+              }
+            }
+          ]
         },
         "odometer_reading_in": {
           "type": "integer"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -55,7 +55,6 @@
         "return_at",
         "rental_location",
         "return_location",
-        "drivers",
         "odometer_reading_in",
         "odometer_reading_out",
         "items"
@@ -99,11 +98,17 @@
           }
         },
         "drivers": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/person"
-          }
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/person"
+              }
+            }
+          ]
         },
         "odometer_reading_in": {
           "type": "integer"

--- a/data/receipt.schema.json
+++ b/data/receipt.schema.json
@@ -55,7 +55,7 @@
         "return_at",
         "rental_location",
         "return_location",
-        "driver_name",
+        "drivers",
         "odometer_reading_in",
         "odometer_reading_out",
         "items"
@@ -98,8 +98,12 @@
             }
           }
         },
-        "driver_name": {
-          "type": "string"
+        "drivers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/person"
+          }
         },
         "odometer_reading_in": {
           "type": "integer"
@@ -369,7 +373,7 @@
           "title": "Currency",
           "description": "ISO 4217 currency code",
           "type": "string",
-          "enum": ["usd", "eur", "jpy", "gbp", "aud", "cad", "chf", "cny"]
+          "pattern": "^[a-z]{3}$"
         },
         "total": {
           "type": "integer"
@@ -1201,7 +1205,7 @@
       "title": "Tax",
       "type": "object",
       "additionalProperties": false,
-      "required": ["amount", "rate", "name"],
+      "required": ["amount", "name"],
       "properties": {
         "amount": {
           "type": "integer"

--- a/examples/itinerary/car_rental.json
+++ b/examples/itinerary/car_rental.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null
@@ -47,7 +47,12 @@
         "description": "Polestar 2",
         "image": "https://versa.org/temp_demo_assets/hertz/polestar2.png"
       },
-      "driver_name": "Henry Ford",
+      "drivers": [
+        {
+          "first_name": "Henry",
+          "last_name": "Ford"
+        }
+      ],
       "odometer_reading_in": 100,
       "odometer_reading_out": 210,
       "metadata": [],

--- a/examples/itinerary/flight.json
+++ b/examples/itinerary/flight.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null

--- a/examples/itinerary/lodging.json
+++ b/examples/itinerary/lodging.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null

--- a/examples/itinerary/rail.json
+++ b/examples/itinerary/rail.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null
@@ -57,9 +57,18 @@
           "arrival_at": 1726867959,
           "polyline": null,
           "metadata": [
-            { "key": "Ticket", "value": "1210653562276" },
-            { "key": "Class", "value": "Coach" },
-            { "key": "Category", "value": "Adult" }
+            {
+              "key": "Ticket",
+              "value": "1210653562276"
+            },
+            {
+              "key": "Class",
+              "value": "Coach"
+            },
+            {
+              "key": "Category",
+              "value": "Adult"
+            }
           ]
         },
         {
@@ -110,9 +119,18 @@
           "arrival_at": 1726867959,
           "polyline": null,
           "metadata": [
-            { "key": "Ticket", "value": "1210653562276" },
-            { "key": "Class", "value": "Coach" },
-            { "key": "Category", "value": "Adult" }
+            {
+              "key": "Ticket",
+              "value": "1210653562276"
+            },
+            {
+              "key": "Class",
+              "value": "Coach"
+            },
+            {
+              "key": "Category",
+              "value": "Adult"
+            }
           ]
         },
         {
@@ -163,9 +181,18 @@
           "arrival_at": 1726867959,
           "polyline": null,
           "metadata": [
-            { "key": "Ticket", "value": "1210653562276" },
-            { "key": "Class", "value": "Coach" },
-            { "key": "Category", "value": "Child" }
+            {
+              "key": "Ticket",
+              "value": "1210653562276"
+            },
+            {
+              "key": "Class",
+              "value": "Coach"
+            },
+            {
+              "key": "Category",
+              "value": "Child"
+            }
           ]
         }
       ]

--- a/examples/itinerary/rideshare.json
+++ b/examples/itinerary/rideshare.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null

--- a/examples/itinerary/service.json
+++ b/examples/itinerary/service.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "third_party": null,
     "customer": null

--- a/examples/receipt/ecommerce.json
+++ b/examples/receipt/ecommerce.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "currency": "usd",
     "subtotal": 12997,

--- a/examples/receipt/flight.json
+++ b/examples/receipt/flight.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "currency": "usd",
     "subtotal": 89600,

--- a/examples/receipt/subscription.json
+++ b/examples/receipt/subscription.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.1.0",
+  "schema_version": "2.1.1",
   "header": {
     "currency": "usd",
     "subtotal": 14997,


### PR DESCRIPTION
- Fix non-optional tax `rate` (all nullable fields should be optional and vice versa)
- Accept any ISO 4217 lower-case currency code using a regex pattern instead of an enum
- **Alpha** Apply the 'person' migration to `car_rental` itemization schema 